### PR TITLE
Add /out dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 /build
+/out
 .gradle
 .classpath
 .project


### PR DESCRIPTION
New version of intelliJ creates`/out` directory when building the project.